### PR TITLE
Change in the distance parameter of the Wallapop API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,20 +27,20 @@
   
 
   ### Parameters:
-  | Parameter                  | Description                                                                                                                                                          | Example                     | Mandatory         |
-  |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|-------------------|
-  | `search_query`             | Main search term. Only items containing this phrase in their title will be found.                                                                                     | `"laptop"`                  | **Yes**          |
-  | `min_price`                | Minimum item price.                                                                                                                                                   | `"100"`                     | **Yes**          |
-  | `max_price`                | Maximum item price.                                                                                                                                                   | `"500"`                     | **Yes**          |
-  | `latitude`                 | Latitude of your location for distance-based filtering.                                                                                                               | `"40.4165"`                 | No               |
-  | `longitude`                | Longitude of your location for distance-based filtering.                                                                                                              | `"-3.70256"`                | No               |
-  | `max_distance`             | Search range (in meters) from the specified latitude/longitude. Use `"0"` for no limit.                                                                              | `"10000"`                   | No               |
-  | `condition`                | Item condition to filter by. Options: `all`, `new`, `as_good_as_new`, `good`, `fair`, `has_given_it_all`.                                                             | `"good"`                    | No               |
-  | `title_exclude`            | List of words that, if present in the title, will exclude an item.                                                                                                    | `["broken", "parts"]`       | No               |
-  | `description_exclude`      | List of words that, if present in the description, will exclude an item.                                                                                              | `["damaged"]`               | No               |
-  | `title_must_include`       | List of required words in the title. If none of these words appear, the item will be excluded.                                                                        | `["Intel", "i5"]`           | No               |
-  | `description_must_include` | List of required words in the description. If none of these words appear, the item will be excluded.                                                                  | `["working"]`               | No               |
-  | `title_first_word_include` | Notify only if the first word of the title matches the specified word.                                                                                                | `"New"`                     | No               |
+  | Parameter                  | Description                                                                                               | Example                  | Mandatory         |
+  |----------------------------|-----------------------------------------------------------------------------------------------------------|--------------------------|-------------------|
+  | `search_query`             | Main search term. Only items containing this phrase in their title will be found.                         | `"laptop"`               | **Yes**          |
+  | `min_price`                | Minimum item price.                                                                                       | `"100"`                  | **Yes**          |
+  | `max_price`                | Maximum item price.                                                                                       | `"500"`                  | **Yes**          |
+  | `latitude`                 | Latitude of your location for distance-based filtering.                                                   | `"40.4165"`              | No               |
+  | `longitude`                | Longitude of your location for distance-based filtering.                                                  | `"-3.70256"`             | No               |
+  | `max_distance`             | Search range (in kilometers) from the specified latitude/longitude. Use `"0"` for no limit.               | `"10"`                   | No               |
+  | `condition`                | Item condition to filter by. Options: `all`, `new`, `as_good_as_new`, `good`, `fair`, `has_given_it_all`. | `"good"`                 | No               |
+  | `title_exclude`            | List of words that, if present in the title, will exclude an item.                                        | `["broken", "parts"]`    | No               |
+  | `description_exclude`      | List of words that, if present in the description, will exclude an item.                                  | `["damaged"]`            | No               |
+  | `title_must_include`       | List of required words in the title. If none of these words appear, the item will be excluded.            | `["Intel", "i5"]`        | No               |
+  | `description_must_include` | List of required words in the description. If none of these words appear, the item will be excluded.      | `["working"]`            | No               |
+  | `title_first_word_include` | Notify only if the first word of the title matches the specified word.                                    | `"New"`                  | No               |
 
 Check out [args.json](./args.json) for an example
 

--- a/managers/worker.py
+++ b/managers/worker.py
@@ -32,7 +32,7 @@ class Worker:
         )
 
         if self._item_monitoring._max_distance != "0":
-            url += f"&distance={self._item_monitoring._max_distance}"
+            url += f"&distance_in_km={self._item_monitoring._max_distance}"
 
         if self._item_monitoring.get_condition() != "all":
             url += f"&condition={self._item_monitoring.get_condition()}"  # new, as_good_as_new, good, fair, has_given_it_all


### PR DESCRIPTION
Looks like the Wallapop API has changed. 

The `distance` parameter doesn't return anything any more, it is now `distance_in_km`