### PR TITLE
Add Docker support for simplified deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Git
+.git
+.gitignore
+
+# Docker
+docker-compose.yml
+Dockerfile
+.dockerignore
+
+# Configs
+searches/
+data/
+config.yaml
+args.json
+
+# Python
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+venv/
+ENV/
+
+# Docs
+README.md
+*.md
+
+# IDE
+.vscode
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y jq && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+COPY requirements.txt .
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["python3", "wallamonitor.py"]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   - [Setup](#setup-)
   - [Configuration](#configuration-)
   - [Usage](#usage-)
+  - [Docker Setup](#docker-setup-)
 
   ## Setup 🔧
 
@@ -54,6 +55,81 @@ Check out [args.json](./args.json) for an example
      ```
 
   The bot will monitor Wallapop periodically (default 15s) and send notifications to your specified Telegram channel whenever new items match your criteria.
+
+  ## Docker Setup 🐳
+
+  Wallamonitor can be easily deployed using Docker, which provides an isolated environment and simplifies dependency management.
+
+  ### Prerequisites
+
+  - Docker installed on your system ([Download Docker](https://www.docker.com/get-started))
+  - Docker Compose (usually included with Docker Desktop)
+
+  ### Environment Setup
+
+  1. Create a `.env` file in the project root with your Telegram credentials:
+     ```env
+     TELEGRAM_CHANNEL=@Your_Telegram_Channel_ID
+     TELEGRAM_TOKEN=Your_Telegram_Bot_Token
+     ```
+
+  2. Create your search configuration file in the `searches/` directory (e.g., `searches/example.json`):
+     ```json
+     [
+       {
+         "search_query": "iphone",
+         "latitude": "40.4165",
+         "longitude": "-3.70256",
+         "max_distance": "0",
+         "condition": "all",
+         "min_price": "0",
+         "max_price": "200",
+         "title_exclude": [],
+         "description_exclude": [],
+         "title_must_include": [],
+         "title_first_word_exclude": "",
+         "description_must_include": []
+       }
+     ]
+     ```
+
+  ### Running with Docker Compose
+
+  The `docker-compose.yml` includes a template service that you can customize:
+
+  1. **Start the default example service:**
+     ```bash
+     docker-compose up -d wallamonitor-example
+     ```
+
+  2. **Add your own monitoring service:**
+     
+     Edit `docker-compose.yml` and add a new service (uncomment and modify the laptops example):
+     ```yaml
+     wallamonitor-laptops:
+       <<: *wallamonitor-base
+       container_name: wallamonitor-laptops
+       volumes:
+         - ./searches/laptops.json:/app/args.json:ro
+     ```
+
+  3. **Run multiple monitors simultaneously:**
+     ```bash
+     docker-compose up -d
+     ```
+     
+     This will start all configured services at once, each monitoring different search criteria.
+
+  4. **View logs:**
+     ```bash
+     docker-compose logs -f wallamonitor-example
+     ```
+
+  5. **Stop the services:**
+     ```bash
+     docker-compose down
+     ```
+
 
   ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+
+x-wallamonitor-template: &wallamonitor-base
+  build: .
+  restart: unless-stopped
+  env_file:
+    - path: ./.env
+      required: true
+  environment:
+    TZ: Europe/Madrid
+
+
+services:
+  wallamonitor-example:
+    <<: *wallamonitor-base
+    container_name: wallamonitor-example
+    volumes:
+      - ./searches/example.json:/app/args.json:ro
+
+  # wallamonitor-laptops:
+  #   <<: *wallamonitor-base
+  #   container_name: wallamonitor-laptops
+  #   volumes:
+  #     - ./env/laptops.env:/app/args.env:ro
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 
 x-wallamonitor-template: &wallamonitor-base
-  build: .
+  build: . # or use git repo if you don't want to clone (e.g., https://github.com/danielhuici/Wallamonitor#main)
   restart: unless-stopped
   env_file:
     - path: ./.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,5 +21,5 @@ services:
   #   <<: *wallamonitor-base
   #   container_name: wallamonitor-laptops
   #   volumes:
-  #     - ./env/laptops.env:/app/args.env:ro
+  #     - ./searches/laptops.json:/app/args.json:ro
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+cat > /app/config.yaml <<EOF
+telegram_channel: "${TELEGRAM_CHANNEL}"
+telegram_token: "${TELEGRAM_TOKEN}"
+EOF
+exec "$@"


### PR DESCRIPTION
## Description

This PR adds Docker support to Wallamonitor, making it easier to deploy and manage multiple instances with different search configurations.

Resolves https://github.com/danielhuici/Wallamonitor/issues/13

## Changes

- **Dockerfile**: Creates a containerized environment with all required dependencies
- **docker-compose.yml**: Template configuration with example deployments
- **entrypoint.sh**: Generates `config.yaml` from environment variables at runtime
- Updated README with instructions on how to deploy the project using Docker

## Usage Example

### Option 1: Clone the repository

1. Clone and navigate to the project
  ```bash
  git clone https://github.com/danielhuici/Wallamonitor.git
  cd Wallamonitor
  ```
2. Add your Telegram credentials to .env file
3. Create your search configuration JSON file
4. Update docker-compose.yml to point to your config file
5. Start containers
```bash
docker-compose up -d
```

### Option 2: Direct deployment (without cloning)

1. Copy docker-compose.yml
2. Change build path to: build: https://github.com/danielhuici/Wallamonitor.git
3. Create your search configuration JSON files
4. Add your Telegram credentials to .env file
5. Start containers
```bash
docker-compose up -d
```